### PR TITLE
Send negative response when the sub-function is missing

### DIFF
--- a/iso14229.c
+++ b/iso14229.c
@@ -1051,29 +1051,12 @@ static uint8_t evaluateServiceResponse(UDSServer_t *self, const uint8_t addressi
     /* test if service with sub-function is supported */
     case kSID_DIAGNOSTIC_SESSION_CONTROL:
     case kSID_ECU_RESET:
-    case kSID_READ_DTC_INFORMATION:
     case kSID_SECURITY_ACCESS:
     case kSID_COMMUNICATION_CONTROL:
     case kSID_ROUTINE_CONTROL:
     case kSID_TESTER_PRESENT:
-    case kSID_ACCESS_TIMING_PARAMETER:
-    case kSID_SECURED_DATA_TRANSMISSION:
-    case kSID_CONTROL_DTC_SETTING:
-    case kSID_RESPONSE_ON_EVENT: {
-
-        /* check minimum length of message with sub-function */
-        if (self->recv_size >= 2) {
-            /* get sub-function parameter value without bit 7 */
-            // switch (ctx->req.as.raw[0] & 0x7F) {
-
-            // }
-            // Let the service callback determine whether or not the sub-function parameter value is
-            // supported
-            response = service(self);
-        } else {
-            /* NRC 0x13: incorrectMessageLengthOrInvalidFormat */
-            response = kIncorrectMessageLengthOrInvalidFormat;
-        }
+    case kSID_CONTROL_DTC_SETTING: {
+        response = service(self);
 
         bool suppressPosRspMsgIndicationBit = self->recv_buf[1] & 0x80;
 
@@ -1093,22 +1076,28 @@ static uint8_t evaluateServiceResponse(UDSServer_t *self, const uint8_t addressi
     /* test if service without sub-function is supported */
     case kSID_READ_DATA_BY_IDENTIFIER:
     case kSID_READ_MEMORY_BY_ADDRESS:
-    case kSID_READ_SCALING_DATA_BY_IDENTIFIER:
-    case kSID_READ_PERIODIC_DATA_BY_IDENTIFIER:
-    case kSID_DYNAMICALLY_DEFINE_DATA_IDENTIFIER:
     case kSID_WRITE_DATA_BY_IDENTIFIER:
     case kSID_REQUEST_DOWNLOAD:
     case kSID_REQUEST_UPLOAD:
     case kSID_TRANSFER_DATA:
-    case kSID_REQUEST_TRANSFER_EXIT:
-    case kSID_REQUEST_FILE_TRANSFER:
-    case kSID_WRITE_MEMORY_BY_ADDRESS:
-    case kSID_CLEAR_DIAGNOSTIC_INFORMATION:
-    case kSID_INPUT_CONTROL_BY_IDENTIFIER: {
+    case kSID_REQUEST_TRANSFER_EXIT: {
         response = service(self);
         break;
     }
 
+    /* CASE Service_not_implemented */
+    /* shouldn't get this far as getServiceForSID(sid) will return NULL*/
+    case kSID_CLEAR_DIAGNOSTIC_INFORMATION:
+    case kSID_READ_DTC_INFORMATION:
+    case kSID_READ_SCALING_DATA_BY_IDENTIFIER:
+    case kSID_READ_PERIODIC_DATA_BY_IDENTIFIER:
+    case kSID_DYNAMICALLY_DEFINE_DATA_IDENTIFIER:
+    case kSID_INPUT_CONTROL_BY_IDENTIFIER:
+    case kSID_REQUEST_FILE_TRANSFER:
+    case kSID_WRITE_MEMORY_BY_ADDRESS:
+    case kSID_ACCESS_TIMING_PARAMETER:
+    case kSID_SECURED_DATA_TRANSMISSION:
+    case kSID_RESPONSE_ON_EVENT:
     default: {
         response = kServiceNotSupported;
         break;


### PR DESCRIPTION
Services that require a sub-function do not currently return a negative response when the sub-function is missing from the request. This fix removes the length check from evaluateServiceResponse() and relies on the fact that the length checks are implemented correctly in the service callbacks.

Also re-ordered the switch statement to make it clearer which services aren't implemented. In reality these services will never be checked in the switch stattement as getServiceForSID() will return NULL and trigger an early exit.