### PR TITLE
fix(isotp_sock.c): add CAN_ISOTP_WAIT_TX_DONE flag to ISOTP sockets

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,2 +1,3 @@
 Nick James Kirkby <iso14229dev@gmail.com>
 Mark Corbin <mcorbin@lunarenergy.com>
+Jens Fernández Mühlke <fernandezjens@gmail.com>

--- a/src/tp/isotp_sock.c
+++ b/src/tp/isotp_sock.c
@@ -147,17 +147,21 @@ static int LinuxSockBind(const char *if_name, uint32_t rxid, uint32_t txid, bool
         perror("setsockopt");
         return -1;
     }
-
+    
+    struct can_isotp_options opts;
+    memset(&opts, 0, sizeof(opts));
+    // configure socket to wait for tx completion to catch FC frame timeouts
+    opts.flags |= CAN_ISOTP_WAIT_TX_DONE;
+ 
     if (functional) {
         printf("configuring fd: %d as functional\n", fd);
         // configure the socket as listen-only to avoid sending FC frames
-        struct can_isotp_options opts;
-        memset(&opts, 0, sizeof(opts));
         opts.flags |= CAN_ISOTP_LISTEN_MODE;
-        if (setsockopt(fd, SOL_CAN_ISOTP, CAN_ISOTP_OPTS, &opts, sizeof(opts)) < 0) {
-            perror("setsockopt (isotp_options):");
-            return -1;
-        }
+    }
+ 
+    if (setsockopt(fd, SOL_CAN_ISOTP, CAN_ISOTP_OPTS, &opts, sizeof(opts)) < 0) {
+        perror("setsockopt (isotp_options):");
+        return -1;
     }
 
     struct ifreq ifr;

--- a/test/test_tp_compliance.c
+++ b/test/test_tp_compliance.c
@@ -95,6 +95,27 @@ void TestISOTPSendRecvMaxLen(void **state) {
     assert_memory_equal(UDSTpGetRecvBuf(srv, NULL), MSG, sizeof(MSG));
 }
 
+void TestISOTPFlowControlFrameTimeout(void **state) {
+    if (!IsISOTP()) {
+        skip();
+    }
+
+    // setup
+    client = ENV_TpNew("client");
+    TPMockLogToStdout();
+
+    // sending multiframe to wait for Flow Control frame
+    // which will not arrive since no server is running
+    const uint8_t MSG[] = {1, 2, 3, 4, 5, 6, 7, 8};
+    ssize_t ret = UDSTpSend(client, MSG, sizeof(MSG), NULL);
+
+    // teardown
+    ENV_TpFree(client);
+
+    // -1 is expected as the elapsed 1s timeout raises an error on the ISOTP socket
+    assert_true(ret < 0);
+}
+
 int main() {
     const struct CMUnitTest tests[] = {
         // cmocka_unit_test_setup_teardown(TestSendRecv, setup, teardown),
@@ -102,6 +123,7 @@ int main() {
         cmocka_unit_test_setup_teardown(TestISOTPSendLargestSingleFrame, setup, teardown),
         cmocka_unit_test_setup_teardown(TestISOTPSendLargerThanSingleFrameFails, setup, teardown),
         cmocka_unit_test_setup_teardown(TestISOTPSendRecvMaxLen, setup, teardown),
+        cmocka_unit_test_setup_teardown(TestISOTPFlowControlFrameTimeout, NULL, NULL),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/test/test_tp_compliance.c
+++ b/test/test_tp_compliance.c
@@ -100,19 +100,15 @@ void TestISOTPFlowControlFrameTimeout(void **state) {
         skip();
     }
 
-    // setup
-    client = ENV_TpNew("client");
-    TPMockLogToStdout();
+    // killing server so that no response is sent to client
+    ENV_TpFree(srv);
 
     // sending multiframe to wait for Flow Control frame
     // which will not arrive since no server is running
     const uint8_t MSG[] = {1, 2, 3, 4, 5, 6, 7, 8};
     ssize_t ret = UDSTpSend(client, MSG, sizeof(MSG), NULL);
 
-    // teardown
-    ENV_TpFree(client);
-
-    // -1 is expected as the elapsed 1s timeout raises an error on the ISOTP socket
+    // failure is expected as the elapsed 1s timeout raises an error on the ISOTP socket
     assert_true(ret < 0);
 }
 
@@ -123,7 +119,7 @@ int main() {
         cmocka_unit_test_setup_teardown(TestISOTPSendLargestSingleFrame, setup, teardown),
         cmocka_unit_test_setup_teardown(TestISOTPSendLargerThanSingleFrameFails, setup, teardown),
         cmocka_unit_test_setup_teardown(TestISOTPSendRecvMaxLen, setup, teardown),
-        cmocka_unit_test_setup_teardown(TestISOTPFlowControlFrameTimeout, NULL, NULL),
+        cmocka_unit_test_setup_teardown(TestISOTPFlowControlFrameTimeout, setup, teardown),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
As of now, an UDS client run on the Linux ISOTP kernel module was not able to recognize a timeout error of a Flow Control frame not arriving in time after a multi-frame request. To fix this, the flag CAN_ISOTP_WAIT_TX_DONE is set on the socket. Otherwise writing the bytes of the SEND buffer to the ISOTP socket would incorrectly return the expected SEND buffer size, creating further problems like e.g. a timeout waiting on the response of the "sent"  request, since it was not really sent so the UDS server is not sending a response.