### PR TITLE
Fix calls to printf

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -44,7 +44,7 @@ static const char *ClientStateName(enum UDSClientRequestState state) {
 }
 
 static void changeState(UDSClient_t *client, enum UDSClientRequestState state) {
-    printf("client state: %s (%d) -> %s (%d)\n", ClientStateName(client->state), client->state,
+    UDS_DBG_PRINT("client state: %s (%d) -> %s (%d)\n", ClientStateName(client->state), client->state,
            ClientStateName(state), state);
     client->state = state;
 }
@@ -212,7 +212,7 @@ static void PollLowLevel(UDSClient_t *client) {
                 changeState(client, kRequestStateIdle);
             }
         } else {
-            printf("received %zd bytes\n", len);
+            UDS_DBG_PRINT("received %zd bytes\n", len);
             client->recv_size = len;
             changeState(client, kRequestStateProcessResponse);
         }

--- a/src/server.c
+++ b/src/server.c
@@ -898,7 +898,7 @@ void UDSServerPoll(UDSServer_t *srv) {
         }
 
         if (UDSTimeAfter(UDSMillis(), srv->p2_timer)) {
-            printf("len: %zu\n", r->send_len);
+            UDS_DBG_PRINT("len: %zu\n", r->send_len);
             ssize_t ret = UDSTpSend(srv->tp, r->send_buf, r->send_len, NULL);
             // TODO test injection of transport errors:
             if (ret < 0) {

--- a/src/sys_arduino.h
+++ b/src/sys_arduino.h
@@ -8,7 +8,9 @@
 #include <Arduino.h>
 
 #define UDS_TP UDS_TP_ISOTP_C
+#ifndef UDS_ENABLE_DBG_PRINT
 #define UDS_ENABLE_DBG_PRINT 1
+#endif
 #define UDS_ENABLE_ASSERT 1
 int print_impl(const char *fmt, ...);
 #define UDS_DBG_PRINT_IMPL print_impl

--- a/src/sys_esp32.h
+++ b/src/sys_esp32.h
@@ -7,7 +7,9 @@
 #include <esp_timer.h>
 
 #define UDS_TP_ISOTP_C 1
+#ifndef UDS_ENABLE_DBG_PRINT
 #define UDS_ENABLE_DBG_PRINT 1
+#endif
 #define UDS_ENABLE_ASSERT 1
 
 #endif

--- a/src/tp/isotp_c.c
+++ b/src/tp/isotp_c.c
@@ -28,7 +28,7 @@ int peek_link(IsoTpLink *link, uint8_t *buf, size_t bufsize, bool functional) {
         goto done;
     case ISOTP_RECEIVE_STATUS_FULL:
         ret = link->receive_size;
-        printf("The link is full. Copying %d bytes\n", ret);
+        UDS_DBG_PRINT("The link is full. Copying %d bytes\n", ret);
         memmove(buf, link->receive_buffer, link->receive_size);
         break;
     default:
@@ -55,7 +55,7 @@ static ssize_t tp_peek(UDSTpHandle_t *hdl, uint8_t **p_buf, UDSSDU_t *info) {
     uint32_t sa = tp->phys_sa;
 
     if (ret > 0) {
-        printf("just got %d bytes\n", ret);
+        UDS_DBG_PRINT("just got %d bytes\n", ret);
         ta = tp->phys_sa;
         sa = tp->phys_ta;
         ta_type = UDS_A_TA_TYPE_PHYSICAL;
@@ -66,7 +66,7 @@ static ssize_t tp_peek(UDSTpHandle_t *hdl, uint8_t **p_buf, UDSSDU_t *info) {
     } else {
         ret = peek_link(&tp->func_link, tp->recv_buf, sizeof(tp->recv_buf), true);
         if (ret > 0) {
-            printf("just got %d bytes on func link \n", ret);
+            UDS_DBG_PRINT("just got %d bytes on func link \n", ret);
             ta = tp->func_sa;
             sa = tp->func_ta;
             ta_type = UDS_A_TA_TYPE_FUNCTIONAL;
@@ -128,7 +128,7 @@ done:
 
 static void tp_ack_recv(UDSTpHandle_t *hdl) {
     assert(hdl);
-    printf("ack recv\n");
+    UDS_DBG_PRINT("ack recv\n");
     UDSISOTpC_t *tp = (UDSISOTpC_t *)hdl;
     uint16_t out_size = 0;
     isotp_receive(&tp->phys_link, tp->recv_buf, sizeof(tp->recv_buf), &out_size);

--- a/src/tp/isotp_c_socketcan.c
+++ b/src/tp/isotp_c_socketcan.c
@@ -121,7 +121,7 @@ static int isotp_c_socketcan_tp_peek_link(IsoTpLink *link, uint8_t *buf, size_t 
         goto done;
     case ISOTP_RECEIVE_STATUS_FULL:
         ret = link->receive_size;
-        printf("The link is full. Copying %d bytes\n", ret);
+        UDS_DBG_PRINT("The link is full. Copying %d bytes\n", ret);
         memmove(buf, link->receive_buffer, link->receive_size);
         break;
     default:
@@ -148,7 +148,7 @@ static ssize_t isotp_c_socketcan_tp_peek(UDSTpHandle_t *hdl, uint8_t **p_buf, UD
     uint32_t sa = tp->phys_sa;
 
     if (ret > 0) {
-        printf("just got %d bytes\n", ret);
+        UDS_DBG_PRINT("just got %d bytes\n", ret);
         ta = tp->phys_sa;
         sa = tp->phys_ta;
         ta_type = UDS_A_TA_TYPE_PHYSICAL;
@@ -160,7 +160,7 @@ static ssize_t isotp_c_socketcan_tp_peek(UDSTpHandle_t *hdl, uint8_t **p_buf, UD
         ret = isotp_c_socketcan_tp_peek_link(&tp->func_link, tp->recv_buf, sizeof(tp->recv_buf),
                                              true);
         if (ret > 0) {
-            printf("just got %d bytes on func link \n", ret);
+            UDS_DBG_PRINT("just got %d bytes on func link \n", ret);
             ta = tp->func_sa;
             sa = tp->func_ta;
             ta_type = UDS_A_TA_TYPE_FUNCTIONAL;
@@ -238,7 +238,7 @@ done:
 
 static void isotp_c_socketcan_tp_ack_recv(UDSTpHandle_t *hdl) {
     assert(hdl);
-    printf("ack recv\n");
+    UDS_DBG_PRINT("ack recv\n");
     UDSTpISOTpC_t *tp = (UDSTpISOTpC_t *)hdl;
     uint16_t out_size = 0;
     isotp_receive(&tp->phys_link, tp->recv_buf, sizeof(tp->recv_buf), &out_size);

--- a/src/tp/isotp_sock.c
+++ b/src/tp/isotp_sock.c
@@ -147,18 +147,18 @@ static int LinuxSockBind(const char *if_name, uint32_t rxid, uint32_t txid, bool
         perror("setsockopt");
         return -1;
     }
-    
+
     struct can_isotp_options opts;
     memset(&opts, 0, sizeof(opts));
     // configure socket to wait for tx completion to catch FC frame timeouts
     opts.flags |= CAN_ISOTP_WAIT_TX_DONE;
- 
+
     if (functional) {
-        printf("configuring fd: %d as functional\n", fd);
+        UDS_DBG_PRINT("configuring fd: %d as functional\n", fd);
         // configure the socket as listen-only to avoid sending FC frames
         opts.flags |= CAN_ISOTP_LISTEN_MODE;
     }
- 
+
     if (setsockopt(fd, SOL_CAN_ISOTP, CAN_ISOTP_OPTS, &opts, sizeof(opts)) < 0) {
         perror("setsockopt (isotp_options):");
         return -1;
@@ -177,7 +177,7 @@ static int LinuxSockBind(const char *if_name, uint32_t rxid, uint32_t txid, bool
     addr.can_ifindex = ifr.ifr_ifindex;
 
     if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
-        printf("Bind: %s %s\n", strerror(errno), if_name);
+        UDS_DBG_PRINT("Bind: %s %s\n", strerror(errno), if_name);
         return -1;
     }
     return fd;
@@ -199,7 +199,7 @@ UDSErr_t UDSTpIsoTpSockInitServer(UDSTpIsoTpSock_t *tp, const char *ifname, uint
     tp->phys_fd = LinuxSockBind(ifname, source_addr, target_addr, false);
     tp->func_fd = LinuxSockBind(ifname, source_addr_func, 0, true);
     if (tp->phys_fd < 0 || tp->func_fd < 0) {
-        printf("foo\n");
+        UDS_DBG_PRINT("foo\n");
         fflush(stdout);
         return UDS_ERR;
     }
@@ -227,7 +227,7 @@ UDSErr_t UDSTpIsoTpSockInitClient(UDSTpIsoTpSock_t *tp, const char *ifname, uint
     if (tp->phys_fd < 0 || tp->func_fd < 0) {
         return UDS_ERR;
     }
-    printf("%s initialized phys link (fd %d) rx 0x%03x tx 0x%03x func link (fd %d) rx 0x%03x tx "
+    UDS_DBG_PRINT("%s initialized phys link (fd %d) rx 0x%03x tx 0x%03x func link (fd %d) rx 0x%03x tx "
            "0x%03x\n",
            strlen(tp->tag) ? tp->tag : "client", tp->phys_fd, source_addr, target_addr, tp->func_fd,
            source_addr, target_addr_func);

--- a/src/tp/mock.c
+++ b/src/tp/mock.c
@@ -149,7 +149,7 @@ static void TPMockDetach(TPMock_t *tp) {
                 TPs[j - 1] = TPs[j];
             }
             TPCount--;
-            printf("TPMock: detached %s. TPCount: %d\n", tp->name, TPCount);
+            UDS_DBG_PRINT("TPMock: detached %s. TPCount: %d\n", tp->name, TPCount);
             return;
         }
     }
@@ -158,7 +158,7 @@ static void TPMockDetach(TPMock_t *tp) {
 
 UDSTpHandle_t *TPMockNew(const char *name, TPMockArgs_t *args) {
     if (TPCount >= MAX_NUM_TP) {
-        printf("TPCount: %d, too many TPs\n", TPCount);
+        UDS_DBG_PRINT("TPCount: %d, too many TPs\n", TPCount);
         return NULL;
     }
     TPMock_t *tp = malloc(sizeof(TPMock_t));


### PR DESCRIPTION
Allow external definition of UDS_ENABLE_DBG_PRINT. 
Replace 'printf' calls with UDS_DBG_PRINT.