### PR TITLE
PR to close #38

### DIFF
--- a/test/env.c
+++ b/test/env.c
@@ -100,6 +100,22 @@ void ENV_RunMillis(uint32_t millis) {
     }
 }
 
+void ENV_RunMillisForTpRegisteredAt(uint32_t millis, unsigned at) {
+    uint32_t end = UDSMillis() + millis;
+    while (UDSMillis() < end) {
+        assert(at >= 0 && at < MAX_NUM_TP);
+
+        UDSTpPoll(registeredTps[at]);
+        TimeNowMillis++;
+
+        // uses vcan, needs delay
+        if (IsNetworkedTransport(opts.tp_type)) {
+            // usleep(10);
+            msleep(1);
+        }
+    }
+}
+
 UDSTpHandle_t *ENV_TpNew(const char *name) {
     ENV_ParseOpts();
     UDSTpHandle_t *tp = NULL;

--- a/test/env.h
+++ b/test/env.h
@@ -42,6 +42,7 @@ void ENV_TpFree(UDSTpHandle_t *tp);
 void ENV_RegisterServer(UDSServer_t *server);
 void ENV_RegisterClient(UDSClient_t *client);
 void ENV_RunMillis(uint32_t millis);
+void ENV_RunMillisForTpRegisteredAt(uint32_t millis, unsigned at);
 const ENV_Opts_t *ENV_GetOpts();
 
 #endif


### PR DESCRIPTION
This PR is aimed at fixing the FC timeout error test case so that it checks this error on both tp implementations (`ISOTP_C` and `ISOTP_SOCK`). 

Tested locally on a Ubuntu machine (24.04.1 LTS, x86_64) with `bazel test //test:all` and all tests passed, just testing the fuzz server was skipped.