### PR TITLE
support for bigger packetsize (>4095)

### DIFF
--- a/src/tp/isotp-c/isotp.c
+++ b/src/tp/isotp-c/isotp.c
@@ -112,7 +112,7 @@ static int isotp_send_first_frame(IsoTpLink* link, uint32_t id) {
         #endif
 
         );
-        if (ISOTP_RET_OK == ret) {
+        if (ISOTP_RET_OK == ret)
             link->send_offset += sizeof(message.as.first_frame_short.data);
     }
     else // ISO15765-2:2016
@@ -131,9 +131,8 @@ static int isotp_send_first_frame(IsoTpLink* link, uint32_t id) {
         #endif
 
         );
-        if (ISOTP_RET_OK == ret) {
+        if (ISOTP_RET_OK == ret)
             link->send_offset += sizeof(message.as.first_frame_long.data);
-        }
     }
 
     link->send_sn = 1;

--- a/src/tp/isotp-c/isotp.h
+++ b/src/tp/isotp-c/isotp.h
@@ -24,12 +24,12 @@ typedef struct IsoTpLink {
     uint32_t                    send_arbitration_id; /* used to reply consecutive frame */
     /* message buffer */
     uint8_t*                    send_buffer;
-    uint16_t                    send_buf_size;
-    uint16_t                    send_size;
-    uint16_t                    send_offset;
+    uint32_t                    send_buf_size;
+    uint32_t                    send_size;
+    uint32_t                    send_offset;
     /* multi-frame flags */
     uint8_t                     send_sn;
-    uint16_t                    send_bs_remain; /* Remaining block size */
+    uint32_t                    send_bs_remain; /* Remaining block size */
     uint32_t                    send_st_min_us; /* Separation Time between consecutive frames */
     uint8_t                     send_wtf_count; /* Maximum number of FC.Wait frame transmissions  */
     uint32_t                    send_timer_st;  /* Last time send consecutive frame */    
@@ -42,9 +42,9 @@ typedef struct IsoTpLink {
     uint32_t                    receive_arbitration_id;
     /* message buffer */
     uint8_t*                    receive_buffer;
-    uint16_t                    receive_buf_size;
-    uint16_t                    receive_size;
-    uint16_t                    receive_offset;
+    uint32_t                    receive_buf_size;
+    uint32_t                    receive_size;
+    uint32_t                    receive_offset;
     /* multi-frame control */
     uint8_t                     receive_sn;
     uint8_t                     receive_bs_count; /* Maximum number of FC.Wait frame transmissions  */
@@ -70,8 +70,8 @@ typedef struct IsoTpLink {
  * @param recvbufsize The size of the buffer area.
  */
 void isotp_init_link(IsoTpLink *link, uint32_t sendid, 
-                     uint8_t *sendbuf, uint16_t sendbufsize,
-                     uint8_t *recvbuf, uint16_t recvbufsize);
+                     uint8_t *sendbuf, uint32_t sendbufsize,
+                     uint8_t *recvbuf, uint32_t recvbufsize);
 
 /**
  * @brief Polling function; call this function periodically to handle timeouts, send consecutive frames, etc.
@@ -106,12 +106,12 @@ void isotp_on_can_message(IsoTpLink *link, const uint8_t *data, uint8_t len);
  *  - @code ISOTP_RET_OK @endcode
  *  - The return value of the user shim function isotp_user_send_can().
  */
-int isotp_send(IsoTpLink *link, const uint8_t payload[], uint16_t size);
+int isotp_send(IsoTpLink *link, const uint8_t payload[], uint32_t size);
 
 /**
  * @brief See @link isotp_send @endlink, with the exception that this function is used only for functional addressing.
  */
-int isotp_send_with_id(IsoTpLink *link, uint32_t id, const uint8_t payload[], uint16_t size);
+int isotp_send_with_id(IsoTpLink *link, uint32_t id, const uint8_t payload[], uint32_t size);
 
 /**
  * @brief Receives and parses the received data and copies the parsed data in to the internal buffer.
@@ -124,7 +124,7 @@ int isotp_send_with_id(IsoTpLink *link, uint32_t id, const uint8_t payload[], ui
  *      - @link ISOTP_RET_OK @endlink
  *      - @link ISOTP_RET_NO_DATA @endlink
  */
-int isotp_receive(IsoTpLink *link, uint8_t *payload, const uint16_t payload_size, uint16_t *out_size);
+int isotp_receive(IsoTpLink *link, uint8_t *payload, const uint32_t payload_size, uint32_t *out_size);
 
 #ifdef __cplusplus
 }

--- a/src/tp/isotp-c/isotp_defines.h
+++ b/src/tp/isotp-c/isotp_defines.h
@@ -31,6 +31,8 @@
 #define __builtin_bswap64 _byteswap_uint64
 #endif
 
+#define LE32TOH(le) ((uint32_t)(((le) << 24) | (((le) & 0x0000FF00) << 8) | (((le) & 0x00FF0000) >> 8) | ((le) >> 24)))
+
 /**************************************************************
  * internal used defines
  *************************************************************/
@@ -83,7 +85,15 @@ typedef struct {
     uint8_t type:4;
     uint8_t FF_DL_low;
     uint8_t data[6];
-} IsoTpFirstFrame;
+} IsoTpFirstFrameShort;
+
+typedef struct __attribute__((packed)) {
+    uint8_t set_to_zero_high:4;
+    uint8_t type:4;
+    uint8_t set_to_zero_low;
+    uint32_t FF_DL;
+    uint8_t data[2];
+} IsoTpFirstFrameLong;
 
 typedef struct {
     uint8_t SN:4;
@@ -124,7 +134,7 @@ typedef struct {
 } IsoTpSingleFrame;
 
 /*
-* first frame
+* first frame short
 * +-------------------------+-----------------------+-----+
 * | byte #0                 | byte #1               | ... |
 * +-------------------------+-----------+-----------+-----+
@@ -184,7 +194,8 @@ typedef struct {
     union {
         IsoTpPciType          common;
         IsoTpSingleFrame      single_frame;
-        IsoTpFirstFrame       first_frame;
+        IsoTpFirstFrameShort  first_frame_short;
+        IsoTpFirstFrameLong   first_frame_long;
         IsoTpConsecutiveFrame consecutive_frame;
         IsoTpFlowControl      flow_control;
         IsoTpDataArray        data_array;


### PR DESCRIPTION
in the ISO 15765-2:2016 support for bigger transfer packets (more than 4095bytes/packet) is defined.
It's working on my side, but i had to swap the bytes for the packetsize (line 124, 218) ... i'm not sure if this fits your coding-style

br