### PR TITLE
add 0x3D WriteMemoryByAddress

### DIFF
--- a/iso14229.c
+++ b/iso14229.c
@@ -1637,6 +1637,47 @@ static UDSErr_t Handle_0x38_RequestFileTransfer(UDSServer_t *srv, UDSReq_t *r) {
     return UDS_PositiveResponse;
 }
 
+static UDSErr_t Handle_0x3D_WriteMemoryByAddress(UDSServer_t *srv, UDSReq_t *r) {
+    UDSErr_t ret = UDS_PositiveResponse;
+    void *address = 0;
+    size_t length = 0;
+
+    if (r->recv_len < UDS_0X3D_REQ_MIN_LEN) {
+        return NegativeResponse(r, UDS_NRC_IncorrectMessageLengthOrInvalidFormat);
+    }
+
+    ret = decodeAddressAndLength(r, &r->recv_buf[1], &address, &length);
+    if (UDS_PositiveResponse != ret) {
+        return NegativeResponse(r, ret);
+    }
+
+    uint8_t memorySizeLength = (r->recv_buf[1] & 0xF0) >> 4;
+    uint8_t memoryAddressLength = r->recv_buf[1] & 0x0F;
+
+    uint8_t dataOffset = 2 + memorySizeLength + memoryAddressLength;
+
+    if (dataOffset + length != r->recv_len) {
+        return NegativeResponse(r, UDS_NRC_IncorrectMessageLengthOrInvalidFormat);
+    }
+
+    UDSWriteMemByAddrArgs_t args = {
+        .memAddr = address,
+        .memSize = length,
+        .data = &r->recv_buf[dataOffset],
+    };
+
+    ret = EmitEvent(srv, UDS_EVT_WriteMemByAddr, &args);
+    if (UDS_PositiveResponse != ret) {
+        return NegativeResponse(r, ret);
+    }
+
+    r->send_buf[0] = UDS_RESPONSE_SID_OF(kSID_WRITE_MEMORY_BY_ADDRESS);
+    // echo addressAndLengthFormatIdentifier, memoryAddress, and memorySize
+    memcpy(&r->send_buf[1], &r->recv_buf[1], 1 + memorySizeLength + memoryAddressLength);
+    r->send_len = UDS_0X3D_RESP_BASE_LEN + memorySizeLength + memoryAddressLength;
+    return UDS_PositiveResponse;
+}
+
 static UDSErr_t Handle_0x3E_TesterPresent(UDSServer_t *srv, UDSReq_t *r) {
     if ((r->recv_len < UDS_0X3E_REQ_MIN_LEN) || (r->recv_len > UDS_0X3E_REQ_MAX_LEN)) {
         return NegativeResponse(r, UDS_NRC_IncorrectMessageLengthOrInvalidFormat);
@@ -1717,7 +1758,7 @@ static UDSService getServiceForSID(uint8_t sid) {
     case kSID_REQUEST_FILE_TRANSFER:
         return Handle_0x38_RequestFileTransfer;
     case kSID_WRITE_MEMORY_BY_ADDRESS:
-        return NULL;
+        return Handle_0x3D_WriteMemoryByAddress;
     case kSID_TESTER_PRESENT:
         return Handle_0x3E_TesterPresent;
     case kSID_ACCESS_TIMING_PARAMETER:

--- a/iso14229.h
+++ b/iso14229.h
@@ -307,6 +307,7 @@ typedef enum UDSEvent {
     UDS_EVT_SecAccessRequestSeed, // UDSSecAccessRequestSeedArgs_t *
     UDS_EVT_SecAccessValidateKey, // UDSSecAccessValidateKeyArgs_t *
     UDS_EVT_WriteDataByIdent,     // UDSWDBIArgs_t *
+    UDS_EVT_WriteMemByAddr,       // UDSWriteMemByAddrArgs_t *
     UDS_EVT_RoutineCtrl,          // UDSRoutineCtrlArgs_t*
     UDS_EVT_RequestDownload,      // UDSRequestDownloadArgs_t*
     UDS_EVT_RequestUpload,        // UDSRequestUploadArgs_t *
@@ -515,6 +516,8 @@ typedef enum {
 #define UDS_0X37_RESP_BASE_LEN 1U
 #define UDS_0X38_REQ_BASE_LEN 9U
 #define UDS_0X38_RESP_BASE_LEN 3U
+#define UDS_0X3D_REQ_MIN_LEN 5U
+#define UDS_0X3D_RESP_BASE_LEN 2U
 #define UDS_0X3E_REQ_MIN_LEN 2U
 #define UDS_0X3E_REQ_MAX_LEN 2U
 #define UDS_0X3E_RESP_LEN 2U
@@ -916,6 +919,12 @@ typedef struct {
     const uint8_t *const data; /*! pointer to data */
     const uint16_t len;        /*! length of data */
 } UDSWDBIArgs_t;
+
+typedef struct {
+    const void *memAddr;       /*! pointer to memory address */
+    const size_t memSize;      /*! size of memory */
+    const uint8_t *const data; /*! pointer to data */
+} UDSWriteMemByAddrArgs_t;
 
 typedef struct {
     const uint8_t ctrlType;      /*! routineControlType */

--- a/src/server.h
+++ b/src/server.h
@@ -124,6 +124,12 @@ typedef struct {
 } UDSWDBIArgs_t;
 
 typedef struct {
+    const void *memAddr;       /*! pointer to memory address */
+    const size_t memSize;      /*! size of memory */
+    const uint8_t *const data; /*! pointer to data */
+} UDSWriteMemByAddrArgs_t;
+
+typedef struct {
     const uint8_t ctrlType;      /*! routineControlType */
     const uint16_t id;           /*! routineIdentifier */
     const uint8_t *optionRecord; /*! optional data */

--- a/src/uds.h
+++ b/src/uds.h
@@ -13,6 +13,7 @@ typedef enum UDSEvent {
     UDS_EVT_SecAccessRequestSeed, // UDSSecAccessRequestSeedArgs_t *
     UDS_EVT_SecAccessValidateKey, // UDSSecAccessValidateKeyArgs_t *
     UDS_EVT_WriteDataByIdent,     // UDSWDBIArgs_t *
+    UDS_EVT_WriteMemByAddr,       // UDSWriteMemByAddrArgs_t *
     UDS_EVT_RoutineCtrl,          // UDSRoutineCtrlArgs_t*
     UDS_EVT_RequestDownload,      // UDSRequestDownloadArgs_t*
     UDS_EVT_RequestUpload,        // UDSRequestUploadArgs_t *
@@ -221,6 +222,8 @@ typedef enum {
 #define UDS_0X37_RESP_BASE_LEN 1U
 #define UDS_0X38_REQ_BASE_LEN 9U
 #define UDS_0X38_RESP_BASE_LEN 3U
+#define UDS_0X3D_REQ_MIN_LEN 5U
+#define UDS_0X3D_RESP_BASE_LEN 2U
 #define UDS_0X3E_REQ_MIN_LEN 2U
 #define UDS_0X3E_REQ_MAX_LEN 2U
 #define UDS_0X3E_RESP_LEN 2U


### PR DESCRIPTION
The following PR should add functionality to support 0x3D WriteMemoryByAddress
- add Handler for 0x3D
- add event and args for WriteMemoryByAddress
- add happy path test using the examples from the standard