### PR TITLE
feat: 0x28 CommControl add NodeID Argument for Ctrl Types 0x04 and 0x05

### DIFF
--- a/iso14229.c
+++ b/iso14229.c
@@ -569,7 +569,7 @@ UDSErr_t UDSSendTransferDataStream(UDSClient_t *client, uint8_t blockSequenceCou
     client->send_buf[0] = kSID_TRANSFER_DATA;
     client->send_buf[1] = blockSequenceCounter;
 
-    unsigned long _size = fread(&client->send_buf[2], 1, blockLength - 2, fd);
+    size_t _size = fread(&client->send_buf[2], 1, blockLength - 2, fd);
     UDS_ASSERT(_size < UINT16_MAX);
     uint16_t size = (uint16_t)_size;
     UDS_LOGI(__FILE__, "size: %d, blocklength: %d", size, blockLength);
@@ -1057,7 +1057,7 @@ static UDSErr_t Handle_0x22_ReadDataByIdentifier(UDSServer_t *srv, UDSReq_t *r) 
             .copy = safe_copy,
         };
 
-        unsigned send_len_before = r->send_len;
+        size_t send_len_before = r->send_len;
         ret = EmitEvent(srv, UDS_EVT_ReadDataByIdent, &args);
         if (ret == UDS_PositiveResponse && send_len_before == r->send_len) {
             UDS_LOGE(__FILE__, "RDBI response positive but no data sent\n");
@@ -1153,10 +1153,8 @@ static UDSErr_t Handle_0x23_ReadMemoryByAddress(UDSServer_t *srv, UDSReq_t *r) {
         return NegativeResponse(r, ret);
     }
     if (r->send_len != UDS_0X23_RESP_BASE_LEN + length) {
-        UDS_LOGE(__FILE__,
-                 "response positive but not all data sent: expected %zu, sent %zu", 
-                 length,
-                 r->send_len - UDS_0X23_RESP_BASE_LEN);
+        UDS_LOGE(__FILE__, "response positive but not all data sent: expected %zu, sent %zu",
+                 length, r->send_len - UDS_0X23_RESP_BASE_LEN);
         return NegativeResponse(r, UDS_NRC_GeneralReject);
     }
     return UDS_PositiveResponse;
@@ -1256,7 +1254,15 @@ static UDSErr_t Handle_0x28_CommunicationControl(UDSServer_t *srv, UDSReq_t *r) 
     UDSCommCtrlArgs_t args = {
         .ctrlType = controlType,
         .commType = communicationType,
+        .nodeId = 0,
     };
+
+    if (args.ctrlType == 0x04 || args.ctrlType == 0x05) {
+        if (r->recv_len < UDS_0X28_REQ_BASE_LEN + 2) {
+            return NegativeResponse(r, UDS_NRC_IncorrectMessageLengthOrInvalidFormat);
+        }
+        args.nodeId = (uint16_t)((uint16_t)(r->recv_buf[3] << 8) | (uint16_t)r->recv_buf[4]);
+    }
 
     UDSErr_t err = EmitEvent(srv, UDS_EVT_CommCtrl, &args);
     if (UDS_PositiveResponse != err) {
@@ -1417,7 +1423,7 @@ static UDSErr_t Handle_0x34_RequestDownload(UDSServer_t *srv, UDSReq_t *r) {
     srv->xferBlockLength = args.maxNumberOfBlockLength;
 
     // ISO-14229-1:2013 Table 401:
-    uint8_t lengthFormatIdentifier = sizeof(args.maxNumberOfBlockLength) << 4;
+    uint8_t lengthFormatIdentifier = (uint8_t)(sizeof(args.maxNumberOfBlockLength) << 4);
 
     /* ISO-14229-1:2013 Table 396: maxNumberOfBlockLength
     This parameter is used by the requestDownload positive response message to
@@ -1433,11 +1439,11 @@ static UDSErr_t Handle_0x34_RequestDownload(UDSServer_t *srv, UDSReq_t *r) {
     r->send_buf[0] = UDS_RESPONSE_SID_OF(kSID_REQUEST_DOWNLOAD);
     r->send_buf[1] = lengthFormatIdentifier;
     for (uint8_t idx = 0; idx < (uint8_t)sizeof(args.maxNumberOfBlockLength); idx++) {
-        uint8_t shiftBytes = sizeof(args.maxNumberOfBlockLength) - 1 - idx;
+        uint8_t shiftBytes = (uint8_t)(sizeof(args.maxNumberOfBlockLength) - 1 - idx);
         uint8_t byte = (args.maxNumberOfBlockLength >> (shiftBytes * 8)) & 0xFF;
         r->send_buf[UDS_0X34_RESP_BASE_LEN + idx] = byte;
     }
-    r->send_len = UDS_0X34_RESP_BASE_LEN + sizeof(args.maxNumberOfBlockLength);
+    r->send_len = UDS_0X34_RESP_BASE_LEN + (size_t)sizeof(args.maxNumberOfBlockLength);
     return UDS_PositiveResponse;
 }
 
@@ -1482,7 +1488,7 @@ static UDSErr_t Handle_0x35_RequestUpload(UDSServer_t *srv, UDSReq_t *r) {
     srv->xferTotalBytes = memorySize;
     srv->xferBlockLength = args.maxNumberOfBlockLength;
 
-    uint8_t lengthFormatIdentifier = sizeof(args.maxNumberOfBlockLength) << 4;
+    uint8_t lengthFormatIdentifier = (uint8_t)(sizeof(args.maxNumberOfBlockLength) << 4);
 
     r->send_buf[0] = UDS_RESPONSE_SID_OF(kSID_REQUEST_UPLOAD);
     r->send_buf[1] = lengthFormatIdentifier;
@@ -1491,7 +1497,7 @@ static UDSErr_t Handle_0x35_RequestUpload(UDSServer_t *srv, UDSReq_t *r) {
         uint8_t byte = (args.maxNumberOfBlockLength >> (shiftBytes * 8)) & 0xFF;
         r->send_buf[UDS_0X35_RESP_BASE_LEN + idx] = byte;
     }
-    r->send_len = UDS_0X35_RESP_BASE_LEN + sizeof(args.maxNumberOfBlockLength);
+    r->send_len = UDS_0X35_RESP_BASE_LEN + (size_t)sizeof(args.maxNumberOfBlockLength);
     return UDS_PositiveResponse;
 }
 
@@ -1641,13 +1647,13 @@ static UDSErr_t Handle_0x38_RequestFileTransfer(UDSServer_t *srv, UDSReq_t *r) {
         }
         for (size_t i = 0; i < file_size_parameter_length; i++) {
             uint8_t data_byte = r->recv_buf[byte_idx];
-            uint8_t shift_by_bytes = file_size_parameter_length - i - 1;
+            uint8_t shift_by_bytes = (uint8_t)(file_size_parameter_length - i - 1);
             file_size_uncompressed |= (size_t)data_byte << (8 * shift_by_bytes);
             byte_idx++;
         }
         for (size_t i = 0; i < file_size_parameter_length; i++) {
             uint8_t data_byte = r->recv_buf[byte_idx];
-            uint8_t shift_by_bytes = file_size_parameter_length - i - 1;
+            uint8_t shift_by_bytes = (uint8_t)(file_size_parameter_length - i - 1);
             file_size_compressed |= (size_t)data_byte << (8 * shift_by_bytes);
             byte_idx++;
         }
@@ -1679,16 +1685,16 @@ static UDSErr_t Handle_0x38_RequestFileTransfer(UDSServer_t *srv, UDSReq_t *r) {
 
     r->send_buf[0] = UDS_RESPONSE_SID_OF(kSID_REQUEST_FILE_TRANSFER);
     r->send_buf[1] = args.modeOfOperation;
-    r->send_buf[2] = sizeof(args.maxNumberOfBlockLength);
+    r->send_buf[2] = (uint8_t)sizeof(args.maxNumberOfBlockLength);
     for (uint8_t idx = 0; idx < (uint8_t)sizeof(args.maxNumberOfBlockLength); idx++) {
-        uint8_t shiftBytes = sizeof(args.maxNumberOfBlockLength) - 1 - idx;
+        uint8_t shiftBytes = (uint8_t)(sizeof(args.maxNumberOfBlockLength) - 1 - idx);
         uint8_t byte = (uint8_t)(args.maxNumberOfBlockLength >> (shiftBytes * 8));
         r->send_buf[UDS_0X38_RESP_BASE_LEN + idx] = byte;
     }
-    r->send_buf[UDS_0X38_RESP_BASE_LEN + sizeof(args.maxNumberOfBlockLength)] =
+    r->send_buf[UDS_0X38_RESP_BASE_LEN + (size_t)sizeof(args.maxNumberOfBlockLength)] =
         args.dataFormatIdentifier;
 
-    r->send_len = UDS_0X38_RESP_BASE_LEN + sizeof(args.maxNumberOfBlockLength) + 1;
+    r->send_len = UDS_0X38_RESP_BASE_LEN + (size_t)sizeof(args.maxNumberOfBlockLength) + 1;
     return UDS_PositiveResponse;
 }
 
@@ -2087,12 +2093,12 @@ uint32_t UDSMillis(void) {
     struct timeval te;
     gettimeofday(&te, NULL); // cppcheck-suppress misra-c2012-21.6
     long long milliseconds = (te.tv_sec * 1000LL) + (te.tv_usec / 1000);
-    return milliseconds;
+    return (uint32_t)milliseconds;
 #elif UDS_SYS == UDS_SYS_WINDOWS
     struct timespec ts;
     timespec_get(&ts, TIME_UTC);
     long long milliseconds = ts.tv_sec * 1000LL + ts.tv_nsec / 1000000;
-    return milliseconds;
+    return (uint32_t)milliseconds;
 #elif UDS_SYS == UDS_SYS_ARDUINO
     return millis();
 #elif UDS_SYS == UDS_SYS_ESP32
@@ -2404,6 +2410,7 @@ bool UDSErrIsNRC(UDSErr_t err) {
 #include <stdio.h>
 #include <stdarg.h>
 
+#if UDS_LOG_LEVEL > UDS_LOG_NONE
 void UDS_LogWrite(UDS_LogLevel_t level, const char *tag, const char *format, ...) {
     va_list list;
     (void)level;
@@ -2421,6 +2428,7 @@ void UDS_LogSDUInternal(UDS_LogLevel_t level, const char *tag, const uint8_t *bu
     }
     UDS_LogWrite(level, tag, "\n");
 }
+#endif
 
 
 #ifdef UDS_LINES
@@ -3106,7 +3114,8 @@ static ssize_t mock_tp_send(struct UDSTp *hdl, uint8_t *buf, size_t len, UDSSDU_
         return -1;
     }
     struct Msg *m = &msgs[MsgCount++];
-    UDSTpAddr_t ta_type = info == NULL ? UDS_A_TA_TYPE_PHYSICAL : info->A_TA_Type;
+    UDSTpAddr_t ta_type =
+        info == NULL ? (UDSTpAddr_t)UDS_A_TA_TYPE_PHYSICAL : (UDSTpAddr_t)info->A_TA_Type;
     m->len = len;
     m->info.A_AE = info == NULL ? 0 : info->A_AE;
     if (UDS_A_TA_TYPE_PHYSICAL == ta_type) {
@@ -3148,7 +3157,7 @@ static ssize_t mock_tp_recv(struct UDSTp *hdl, uint8_t *buf, size_t bufsize, UDS
         UDS_LOGW(__FILE__, "mock_tp_recv: buffer too small: %ld < %ld", bufsize, tp->recv_len);
         return -1;
     }
-    int len = tp->recv_len;
+    ssize_t len = (ssize_t)tp->recv_len;
     memmove(buf, tp->recv_buf, tp->recv_len);
     if (info) {
         *info = tp->recv_info;
@@ -3158,6 +3167,7 @@ static ssize_t mock_tp_recv(struct UDSTp *hdl, uint8_t *buf, size_t bufsize, UDS
 }
 
 static UDSTpStatus_t mock_tp_poll(struct UDSTp *hdl) {
+    (void)hdl; // unused parameter
     NetworkPoll();
     // todo: make this status reflect TX time
     return UDS_TP_IDLE;

--- a/iso14229.h
+++ b/iso14229.h
@@ -571,9 +571,7 @@ enum UDSDiagnosticServiceId {
 #endif
 
 /* returns true if `a` is after `b` */
-static inline bool UDSTimeAfter(uint32_t a, uint32_t b) {
-    return (int32_t)(a - b) > 0;
-}
+static inline bool UDSTimeAfter(uint32_t a, uint32_t b) { return (int32_t)(a - b) > 0; }
 
 /**
  * @brief Get time in milliseconds
@@ -641,47 +639,47 @@ typedef enum {
 #define UDS_LOG_FORMAT(letter, format)                                                             \
     UDS_LOG_COLOR_##letter #letter " (%" PRIu32 ") %s: " format UDS_LOG_RESET_COLOR "\n"
 
-#define UDS_LOG_AT_LEVEL(level, tag, format, ...)                                                  \
-    do {                                                                                           \
-        if (level == UDS_LOG_ERROR) {                                                              \
-            UDS_LogWrite(UDS_LOG_ERROR, tag, UDS_LOG_FORMAT(E, format), UDSMillis(), tag,          \
-                         ##__VA_ARGS__);                                                           \
-        } else if (level == UDS_LOG_WARN) {                                                        \
-            UDS_LogWrite(UDS_LOG_WARN, tag, UDS_LOG_FORMAT(W, format), UDSMillis(), tag,           \
-                         ##__VA_ARGS__);                                                           \
-        } else if (level == UDS_LOG_INFO) {                                                        \
-            UDS_LogWrite(UDS_LOG_INFO, tag, UDS_LOG_FORMAT(I, format), UDSMillis(), tag,           \
-                         ##__VA_ARGS__);                                                           \
-        } else if (level == UDS_LOG_DEBUG) {                                                       \
-            UDS_LogWrite(UDS_LOG_DEBUG, tag, UDS_LOG_FORMAT(D, format), UDSMillis(), tag,          \
-                         ##__VA_ARGS__);                                                           \
-        } else if (level == UDS_LOG_VERBOSE) {                                                     \
-            UDS_LogWrite(UDS_LOG_VERBOSE, tag, UDS_LOG_FORMAT(V, format), UDSMillis(), tag,        \
-                         ##__VA_ARGS__);                                                           \
-        } else {                                                                                   \
-            ;                                                                                      \
-        }                                                                                          \
-    } while (0)
+#if UDS_LOG_LEVEL >= UDS_LOG_ERROR && UDS_LOG_LEVEL > UDS_LOG_NONE
+#define UDS_LOGE(tag, format, ...)                                                                 \
+    UDS_LogWrite(UDS_LOG_ERROR, tag, UDS_LOG_FORMAT(E, format), UDSMillis(), tag, ##__VA_ARGS__)
+#else
+#define UDS_LOGE(tag, format, ...) UDS_LogDummy(tag, format, ##__VA_ARGS__)
+#endif
 
-#define UDS_LOG_AT_LEVEL_LOCAL(level, tag, format, ...)                                            \
-    do {                                                                                           \
-        if (UDS_LOG_LEVEL >= level)                                                                \
-            UDS_LOG_AT_LEVEL(level, tag, format, ##__VA_ARGS__);                                   \
-    } while (0)
+#if UDS_LOG_LEVEL >= UDS_LOG_WARN && UDS_LOG_LEVEL > UDS_LOG_NONE
+#define UDS_LOGW(tag, format, ...)                                                                 \
+    UDS_LogWrite(UDS_LOG_WARN, tag, UDS_LOG_FORMAT(W, format), UDSMillis(), tag, ##__VA_ARGS__)
+#else
+#define UDS_LOGW(tag, format, ...) UDS_LogDummy(tag, format, ##__VA_ARGS__)
+#endif
 
-#define UDS_LOGE(tag, format, ...) UDS_LOG_AT_LEVEL_LOCAL(UDS_LOG_ERROR, tag, format, ##__VA_ARGS__)
-#define UDS_LOGW(tag, format, ...) UDS_LOG_AT_LEVEL_LOCAL(UDS_LOG_WARN, tag, format, ##__VA_ARGS__)
-#define UDS_LOGI(tag, format, ...) UDS_LOG_AT_LEVEL_LOCAL(UDS_LOG_INFO, tag, format, ##__VA_ARGS__)
-#define UDS_LOGD(tag, format, ...) UDS_LOG_AT_LEVEL_LOCAL(UDS_LOG_DEBUG, tag, format, ##__VA_ARGS__)
+#if UDS_LOG_LEVEL >= UDS_LOG_INFO && UDS_LOG_LEVEL > UDS_LOG_NONE
+#define UDS_LOGI(tag, format, ...)                                                                 \
+    UDS_LogWrite(UDS_LOG_INFO, tag, UDS_LOG_FORMAT(I, format), UDSMillis(), tag, ##__VA_ARGS__)
+#else
+#define UDS_LOGI(tag, format, ...) UDS_LogDummy(tag, format, ##__VA_ARGS__)
+#endif
+
+#if UDS_LOG_LEVEL >= UDS_LOG_DEBUG && UDS_LOG_LEVEL > UDS_LOG_NONE
+#define UDS_LOGD(tag, format, ...)                                                                 \
+    UDS_LogWrite(UDS_LOG_DEBUG, tag, UDS_LOG_FORMAT(D, format), UDSMillis(), tag, ##__VA_ARGS__)
+#else
+#define UDS_LOGD(tag, format, ...) UDS_LogDummy(tag, format, ##__VA_ARGS__)
+#endif
+
+#if UDS_LOG_LEVEL >= UDS_LOG_VERBOSE && UDS_LOG_LEVEL > UDS_LOG_NONE
 #define UDS_LOGV(tag, format, ...)                                                                 \
-    UDS_LOG_AT_LEVEL_LOCAL(UDS_LOG_VERBOSE, tag, format, ##__VA_ARGS__)
+    UDS_LogWrite(UDS_LOG_VERBOSE, tag, UDS_LOG_FORMAT(V, format), UDSMillis(), tag, ##__VA_ARGS__)
+#else
+#define UDS_LOGV(tag, format, ...) UDS_LogDummy(tag, format, ##__VA_ARGS__)
+#endif
 
+#if UDS_LOG_LEVEL >= UDS_LOG_DEBUG && UDS_LOG_LEVEL > UDS_LOG_NONE
 #define UDS_LOG_SDU(tag, buffer, buff_len, info)                                                   \
-    do {                                                                                           \
-        if (UDS_LOG_LEVEL >= (UDS_LOG_DEBUG)) {                                                    \
-            UDS_LogSDUInternal(UDS_LOG_DEBUG, tag, buffer, buff_len, info);                        \
-        }                                                                                          \
-    } while (0)
+    UDS_LogSDUInternal(UDS_LOG_DEBUG, tag, buffer, buff_len, info)
+#else
+#define UDS_LOG_SDU(tag, buffer, buff_len, info) UDS_LogSDUDummy(tag, buffer, buff_len, info)
+#endif
 
 #if defined(__GNUC__) || defined(__clang__)
 #define UDS_PRINTF_FORMAT(fmt_index, first_arg)                                                    \
@@ -690,10 +688,25 @@ typedef enum {
 #define UDS_PRINTF_FORMAT(fmt_index, first_arg)
 #endif
 
+#if UDS_LOG_LEVEL > UDS_LOG_NONE
 void UDS_LogWrite(UDS_LogLevel_t level, const char *tag, const char *format, ...)
     UDS_PRINTF_FORMAT(3, 4);
 void UDS_LogSDUInternal(UDS_LogLevel_t level, const char *tag, const uint8_t *buffer,
                         size_t buff_len, UDSSDU_t *info);
+#else
+// Dummy function that consumes arguments but does nothing
+static inline void UDS_LogDummy(const char *tag, const char *format, ...) {
+    (void)tag;
+    (void)format;
+}
+static inline void UDS_LogSDUDummy(const char *tag, const uint8_t *buffer, size_t buff_len,
+                                   void *info) {
+    (void)tag;
+    (void)buffer;
+    (void)buff_len;
+    (void)info;
+}
+#endif
 
 
 
@@ -908,8 +921,9 @@ typedef struct {
 } UDSReadMemByAddrArgs_t;
 
 typedef struct {
-    uint8_t ctrlType; /* uint8_t */
-    uint8_t commType; /* uint8_t */
+    uint8_t ctrlType; /*! ControlType */
+    uint8_t commType; /*! CommunicationType */
+    uint16_t nodeId;  /*! NodeIdentificationNumber (only used when ctrlType is 0x04 or 0x05) */
 } UDSCommCtrlArgs_t;
 
 typedef struct {

--- a/src/server.c
+++ b/src/server.c
@@ -390,7 +390,15 @@ static UDSErr_t Handle_0x28_CommunicationControl(UDSServer_t *srv, UDSReq_t *r) 
     UDSCommCtrlArgs_t args = {
         .ctrlType = controlType,
         .commType = communicationType,
+        .nodeId = 0,
     };
+
+    if (args.ctrlType == 0x04 || args.ctrlType == 0x05) {
+        if (r->recv_len < UDS_0X28_REQ_BASE_LEN + 2) {
+            return NegativeResponse(r, UDS_NRC_IncorrectMessageLengthOrInvalidFormat);
+        }
+        args.nodeId = (uint16_t)((uint16_t)(r->recv_buf[3] << 8) | (uint16_t)r->recv_buf[4]);
+    }
 
     UDSErr_t err = EmitEvent(srv, UDS_EVT_CommCtrl, &args);
     if (UDS_PositiveResponse != err) {

--- a/src/server.h
+++ b/src/server.h
@@ -105,8 +105,9 @@ typedef struct {
 } UDSReadMemByAddrArgs_t;
 
 typedef struct {
-    uint8_t ctrlType; /* uint8_t */
-    uint8_t commType; /* uint8_t */
+    uint8_t ctrlType; /*! ControlType */
+    uint8_t commType; /*! CommunicationType */
+    uint16_t nodeId;  /*! NodeIdentificationNumber (only used when ctrlType is 0x04 or 0x05) */
 } UDSCommCtrlArgs_t;
 
 typedef struct {

--- a/test/test_server.c
+++ b/test/test_server.c
@@ -697,6 +697,144 @@ void test_0x27_brute_force_prevention_2(void **state) {
     TEST_MEMORY_EQUAL(buf, DENIED, sizeof(DENIED));
 }
 
+UDSErr_t fn_test_0x28_comm_ctrl(UDSServer_t *srv, UDSEvent_t ev, void *arg) {
+    TEST_INT_EQUAL(ev, UDS_EVT_CommCtrl);
+
+    UDSCommCtrlArgs_t *args = arg;
+
+    switch (args->ctrlType) {
+    case 0x01:
+        TEST_INT_EQUAL(args->commType, 0x02);
+        TEST_INT_EQUAL(args->nodeId, 0x00); /* Default NodeID should be 0 */
+        return UDS_PositiveResponse;
+    case 0x02:
+        srv->r.send_len = 1; /* Force malformed response length */
+        return UDS_PositiveResponse;
+
+    case 0x04:
+        TEST_INT_EQUAL(args->commType, 0x01);
+        TEST_INT_EQUAL(args->nodeId, 0x000A);
+        return UDS_PositiveResponse;
+    }
+
+    return UDS_NRC_GeneralProgrammingFailure;
+}
+
+// ISO14229-1 2020 10.5.5 Message flow example CommunicationControl (disable transmission of network
+// management messages)
+void test_0x28_comm_ctrl_example1(void **state) {
+    Env_t *e = *state;
+    uint8_t buf[20] = {0};
+
+    e->server->fn = fn_test_0x28_comm_ctrl;
+    e->server->fn_data = NULL;
+
+    /* Request per ISO14229-1 2020 Table 59 */
+    const uint8_t REQ[] = {
+        0x28, /* SID */
+        0x01, /* ControlType */
+        0x02, /* CommunicationType */
+    };
+
+    UDSTpSend(e->client_tp, REQ, sizeof(REQ), NULL);
+
+    /* Response per ISO14229-1 2020 Table 60 */
+    const uint8_t EXPECTED_RESP1[] = {
+        0x68, /* Response SID */
+        0x01, /* ControlType */
+    };
+
+    /* the client transport should receive a response within client_p2 ms */
+    EXPECT_WITHIN_MS(e, UDSTpRecv(e->client_tp, buf, sizeof(buf), NULL) > 0,
+                     UDS_CLIENT_DEFAULT_P2_MS);
+    TEST_MEMORY_EQUAL(buf, EXPECTED_RESP1, sizeof(EXPECTED_RESP1));
+}
+
+// ISO14229-1 2020 10.5.6 Message flow example CommunicationControl (switch a remote network into
+// the diagnostic-only scheduling mode where the node with address 000A16 is connected to)
+void test_0x28_comm_ctrl_example2(void **state) {
+    Env_t *e = *state;
+    uint8_t buf[20] = {0};
+
+    e->server->fn = fn_test_0x28_comm_ctrl;
+    e->server->fn_data = NULL;
+
+    /* Request per ISO14229-1 2020 Table 61 */
+    const uint8_t REQ[] = {
+        0x28, /* SID */
+        0x04, /* ControlType */
+        0x01, /* CommunicationType */
+        0x00, /* NodeIdentificationNumber [High Byte] */
+        0x0A, /* NodeIdentificationNumber [Low Byte] */
+    };
+
+    UDSTpSend(e->client_tp, REQ, sizeof(REQ), NULL);
+
+    /* Response per ISO14229-1 2020 Table 62 */
+    const uint8_t EXPECTED_RESP1[] = {
+        0x68, /* Response SID */
+        0x04, /* ControlType */
+    };
+
+    /* the client transport should receive a response within client_p2 ms */
+    EXPECT_WITHIN_MS(e, UDSTpRecv(e->client_tp, buf, sizeof(buf), NULL) > 0,
+                     UDS_CLIENT_DEFAULT_P2_MS);
+    TEST_MEMORY_EQUAL(buf, EXPECTED_RESP1, sizeof(EXPECTED_RESP1));
+}
+
+void test_0x28_comm_ctrl_invalid_request(void **state) {
+    Env_t *e = *state;
+    uint8_t buf[20] = {0};
+
+    e->server->fn = fn_test_0x28_comm_ctrl;
+    e->server->fn_data = NULL;
+
+    const uint8_t REQ[] = {
+        0x28, /* SID */
+        0x04, /* ControlType */
+        /* MISSING required CommunicationType */
+    };
+
+    UDSTpSend(e->client_tp, REQ, sizeof(REQ), NULL);
+
+    const uint8_t EXPECTED_RESP1[] = {
+        0x7F, /* Response SID */
+        0x28, /* Original Request SID */
+        0x13, /* NRC: IncorrectMessageLengthOrInvalidFormat*/
+    };
+
+    /* the client transport should receive a response within client_p2 ms */
+    EXPECT_WITHIN_MS(e, UDSTpRecv(e->client_tp, buf, sizeof(buf), NULL) > 0,
+                     UDS_CLIENT_DEFAULT_P2_MS);
+    TEST_MEMORY_EQUAL(buf, EXPECTED_RESP1, sizeof(EXPECTED_RESP1));
+}
+
+void test_0x28_comm_ctrl_forced_malformed_response_in_event_handler(void **state) {
+    Env_t *e = *state;
+    uint8_t buf[20] = {0};
+
+    e->server->fn = fn_test_0x28_comm_ctrl;
+    e->server->fn_data = NULL;
+
+    const uint8_t REQ[] = {
+        0x28, /* SID */
+        0x02, /* ControlType */
+        0x02, /* CommunicationType */
+    };
+
+    UDSTpSend(e->client_tp, REQ, sizeof(REQ), NULL);
+
+    const uint8_t EXPECTED_RESP1[] = {
+        0x68, /* Response SID */
+        0x02, /* Original Request SID */
+    };
+
+    /* the client transport should receive a response within client_p2 ms */
+    EXPECT_WITHIN_MS(e, UDSTpRecv(e->client_tp, buf, sizeof(buf), NULL) > 0,
+                     UDS_CLIENT_DEFAULT_P2_MS);
+    TEST_MEMORY_EQUAL(buf, EXPECTED_RESP1, sizeof(EXPECTED_RESP1));
+}
+
 int fn_test_0x2F(UDSServer_t *srv, UDSEvent_t ev, void *arg) {
     UDSIOCtrlArgs_t *args = arg;
 
@@ -1120,6 +1258,11 @@ int main(int ac, char **av) {
         cmocka_unit_test_setup_teardown(test_0x27_unlock, Setup, Teardown),
         cmocka_unit_test_setup_teardown(test_0x27_brute_force_prevention_1, Setup, Teardown),
         cmocka_unit_test_setup_teardown(test_0x27_brute_force_prevention_2, Setup, Teardown),
+        cmocka_unit_test_setup_teardown(test_0x28_comm_ctrl_example1, Setup, Teardown),
+        cmocka_unit_test_setup_teardown(test_0x28_comm_ctrl_example2, Setup, Teardown),
+        cmocka_unit_test_setup_teardown(test_0x28_comm_ctrl_invalid_request, Setup, Teardown),
+        cmocka_unit_test_setup_teardown(
+            test_0x28_comm_ctrl_forced_malformed_response_in_event_handler, Setup, Teardown),
         cmocka_unit_test_setup_teardown(test_0x2F_example, Setup, Teardown),
         cmocka_unit_test_setup_teardown(test_0x2F_incorrect_request_length, Setup, Teardown),
         cmocka_unit_test_setup_teardown(test_0x2F_negative_response, Setup, Teardown),


### PR DESCRIPTION
- added the `nodeId` field in the `UDSCommCtrlArgs_t` as it is required for control types 0x04 and 0x05
- added tests for 0x28 CommControl


As always, the iso14229.c/h files were created with a slightly differend bazel/gcc version:

```diff
diff --git a/.bazelversion b/.bazelversion
index 0e79152..6da4de5 100644
--- a/.bazelversion
+++ b/.bazelversion
@@ -1 +1 @@
-8.1.1
+8.4.1
diff --git a/toolchain/BUILD b/toolchain/BUILD
index 6ee76bc..c05efe6 100644
--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -77,6 +77,8 @@ gcc_toolchain(
     include_dirs = [
         "/usr/lib/gcc/x86_64-linux-gnu/11/include/",
         '/usr/lib/gcc/x86_64-linux-gnu/13/include/',
+        '/usr/lib/gcc/x86_64-linux-gnu/13/include/',
+        '/usr/lib/gcc/x86_64-pc-linux-gnu/15.2.1/include/',
     ],
     target_compatible_with = [
         "@platforms//cpu:x86_64",

```