### PR TITLE
add 0x85 controlDTCSetting

### DIFF
--- a/iso14229.c
+++ b/iso14229.c
@@ -2029,10 +2029,22 @@ static UDSErr_t Handle_0x85_ControlDTCSetting(UDSServer_t *srv, UDSReq_t *r) {
     if (r->recv_len < UDS_0X85_REQ_BASE_LEN) {
         return NegativeResponse(r, UDS_NRC_IncorrectMessageLengthOrInvalidFormat);
     }
-    uint8_t dtcSettingType = r->recv_buf[1] & 0x3F;
+
+    uint8_t type = r->recv_buf[1] & 0x7F;
+
+    UDSControlDTCSettingArgs_t args = {
+        .type = type,
+        .data = r->recv_len > UDS_0X85_REQ_BASE_LEN ? &r->recv_buf[UDS_0X85_REQ_BASE_LEN] : NULL,
+        .len = r->recv_len > UDS_0X85_REQ_BASE_LEN ? r->recv_len - UDS_0X85_REQ_BASE_LEN : 0,
+    };
+
+    int ret = EmitEvent(srv, UDS_EVT_ControlDTCSetting, &args);
+    if (UDS_PositiveResponse != ret) {
+        return NegativeResponse(r, ret);
+    }
 
     r->send_buf[0] = UDS_RESPONSE_SID_OF(kSID_CONTROL_DTC_SETTING);
-    r->send_buf[1] = dtcSettingType;
+    r->send_buf[1] = type;
     r->send_len = UDS_0X85_RESP_LEN;
     return UDS_PositiveResponse;
 }

--- a/iso14229.h
+++ b/iso14229.h
@@ -319,6 +319,7 @@ typedef enum UDSEvent {
     UDS_EVT_SessionTimeout,       // NULL
     UDS_EVT_DoScheduledReset,     // uint8_t *
     UDS_EVT_RequestFileTransfer,  // UDSRequestFileTransferArgs_t *
+    UDS_EVT_ControlDTCSetting,    // UDSControlDTCSettingArgs_t *
     UDS_EVT_Custom,               // UDSCustomArgs_t *
 
     // Client Event
@@ -1058,6 +1059,12 @@ typedef struct {
     uint16_t maxNumberOfBlockLength;    /*! optional response: inform client how many data bytes to
                                            send in each    `TransferData` request */
 } UDSRequestFileTransferArgs_t;
+
+typedef struct {
+    uint8_t type; /*! invoked subfunction */
+    size_t len;   /*! length of data */
+    void *data;   /*! DTCSettingControlOptionRecord */
+} UDSControlDTCSettingArgs_t;
 
 typedef struct {
     const uint16_t sid;          /*! serviceIdentifier */

--- a/src/server.c
+++ b/src/server.c
@@ -1155,10 +1155,22 @@ static UDSErr_t Handle_0x85_ControlDTCSetting(UDSServer_t *srv, UDSReq_t *r) {
     if (r->recv_len < UDS_0X85_REQ_BASE_LEN) {
         return NegativeResponse(r, UDS_NRC_IncorrectMessageLengthOrInvalidFormat);
     }
-    uint8_t dtcSettingType = r->recv_buf[1] & 0x3F;
+
+    uint8_t type = r->recv_buf[1] & 0x7F;
+
+    UDSControlDTCSettingArgs_t args = {
+        .type = type,
+        .data = r->recv_len > UDS_0X85_REQ_BASE_LEN ? &r->recv_buf[UDS_0X85_REQ_BASE_LEN] : NULL,
+        .len = r->recv_len > UDS_0X85_REQ_BASE_LEN ? r->recv_len - UDS_0X85_REQ_BASE_LEN : 0,
+    };
+
+    int ret = EmitEvent(srv, UDS_EVT_ControlDTCSetting, &args);
+    if (UDS_PositiveResponse != ret) {
+        return NegativeResponse(r, ret);
+    }
 
     r->send_buf[0] = UDS_RESPONSE_SID_OF(kSID_CONTROL_DTC_SETTING);
-    r->send_buf[1] = dtcSettingType;
+    r->send_buf[1] = type;
     r->send_len = UDS_0X85_RESP_LEN;
     return UDS_PositiveResponse;
 }

--- a/src/server.h
+++ b/src/server.h
@@ -241,6 +241,12 @@ typedef struct {
 } UDSRequestFileTransferArgs_t;
 
 typedef struct {
+    uint8_t type; /*! invoked subfunction */
+    size_t len;   /*! length of data */
+    void *data;   /*! DTCSettingControlOptionRecord */
+} UDSControlDTCSettingArgs_t;
+
+typedef struct {
     const uint16_t sid;          /*! serviceIdentifier */
     const uint8_t *optionRecord; /*! optional data */
     const uint16_t len;          /*! length of optional data */

--- a/src/uds.h
+++ b/src/uds.h
@@ -25,6 +25,7 @@ typedef enum UDSEvent {
     UDS_EVT_SessionTimeout,       // NULL
     UDS_EVT_DoScheduledReset,     // uint8_t *
     UDS_EVT_RequestFileTransfer,  // UDSRequestFileTransferArgs_t *
+    UDS_EVT_ControlDTCSetting,    // UDSControlDTCSettingArgs_t *
     UDS_EVT_Custom,               // UDSCustomArgs_t *
 
     // Client Event

--- a/test/test_server.c
+++ b/test/test_server.c
@@ -3358,6 +3358,130 @@ void test_0x3e_suppress_positive_response(void **state) {
     TEST_INT_EQUAL(UDSTpRecv(e->client_tp, buf, sizeof(buf), NULL), 0);
 }
 
+UDSErr_t fn_test_0x85_control_dtc_setting(UDSServer_t *srv, UDSEvent_t ev, void *arg) {
+    TEST_INT_EQUAL(ev, UDS_EVT_ControlDTCSetting);
+
+    UDSControlDTCSettingArgs_t *args = arg;
+
+    switch (args->type) {
+    case 0x01:
+        return UDS_PositiveResponse;
+    case 0x02:
+        TEST_INT_EQUAL(args->len, 2)
+        uint8_t expected_data[] = {0xF1, 0xF2};
+        TEST_MEMORY_EQUAL(args->data, expected_data, sizeof(expected_data))
+        return UDS_PositiveResponse;
+    case 0x40:
+        return UDS_NRC_ConditionsNotCorrect;
+    }
+
+    return UDS_NRC_GeneralProgrammingFailure;
+}
+
+void test_0x85_control_dtc_setting(void **state) {
+    Env_t *e = *state;
+    uint8_t buf[20] = {0};
+
+    e->server->fn = fn_test_0x85_control_dtc_setting;
+    e->server->fn_data = NULL;
+
+    const uint8_t REQ[] = {
+        0x85, /* SID */
+        0x01, /* SubFunction */
+    };
+
+    UDSTpSend(e->client_tp, REQ, sizeof(REQ), NULL);
+
+    const uint8_t EXPECTED_RESP[] = {
+        0xC5, /* Response SID */
+        0x01, /* SubFunction */
+    };
+
+    /* the client transport should receive a response within client_p2 ms */
+    EXPECT_WITHIN_MS(e, UDSTpRecv(e->client_tp, buf, sizeof(buf), NULL) > 0,
+                     UDS_CLIENT_DEFAULT_P2_MS);
+    TEST_MEMORY_EQUAL(buf, EXPECTED_RESP, sizeof(EXPECTED_RESP));
+}
+
+void test_0x85_control_dtc_setting_with_control_data(void **state) {
+    Env_t *e = *state;
+    uint8_t buf[20] = {0};
+
+    e->server->fn = fn_test_0x85_control_dtc_setting;
+    e->server->fn_data = NULL;
+
+    const uint8_t REQ[] = {
+        0x85, /* SID */
+        0x02, /* SubFunction */
+        0xF1, /* DTCSettingControlOptionRecord#1 */
+        0xF2, /* DTCSettingControlOptionRecord#2 */
+    };
+
+    UDSTpSend(e->client_tp, REQ, sizeof(REQ), NULL);
+
+    const uint8_t EXPECTED_RESP[] = {
+        0xC5, /* Response SID */
+        0x02, /* SubFunction */
+    };
+
+    /* the client transport should receive a response within client_p2 ms */
+    EXPECT_WITHIN_MS(e, UDSTpRecv(e->client_tp, buf, sizeof(buf), NULL) > 0,
+                     UDS_CLIENT_DEFAULT_P2_MS);
+    TEST_MEMORY_EQUAL(buf, EXPECTED_RESP, sizeof(EXPECTED_RESP));
+}
+
+void test_0x85_control_dtc_setting_request_too_short(void **state) {
+    Env_t *e = *state;
+    uint8_t buf[20] = {0};
+
+    e->server->fn = fn_test_0x85_control_dtc_setting;
+    e->server->fn_data = NULL;
+
+    const uint8_t REQ[] = {
+        0x85, /* SID */
+              /* Missing required SubFunction */
+    };
+
+    UDSTpSend(e->client_tp, REQ, sizeof(REQ), NULL);
+
+    const uint8_t EXPECTED_RESP[] = {
+        0x7F, /* Response SID */
+        0x85, /* Original Request SID */
+        0x13, /* NRC: IncorrectMessageLengthOrInvalidFormat */
+    };
+
+    /* the client transport should receive a response within client_p2 ms */
+    EXPECT_WITHIN_MS(e, UDSTpRecv(e->client_tp, buf, sizeof(buf), NULL) > 0,
+                     UDS_CLIENT_DEFAULT_P2_MS);
+    TEST_MEMORY_EQUAL(buf, EXPECTED_RESP, sizeof(EXPECTED_RESP));
+}
+
+void test_0x85_control_dtc_setting_request_returns_negative_response(void **state) {
+    Env_t *e = *state;
+    uint8_t buf[20] = {0};
+
+    e->server->fn = fn_test_0x85_control_dtc_setting;
+    e->server->fn_data = NULL;
+
+    const uint8_t REQ[] = {
+        0x85, /* SID */
+        0x40, /* SubFunction */
+    };
+
+    UDSTpSend(e->client_tp, REQ, sizeof(REQ), NULL);
+
+    const uint8_t EXPECTED_RESP[] = {
+        0x7F, /* Response SID */
+        0x85, /* Original Request SID */
+        0x22, /* NRC: ConditionsNotCorrect */
+    };
+
+    /* the client transport should receive a response within client_p2 ms */
+    EXPECT_WITHIN_MS(e, UDSTpRecv(e->client_tp, buf, sizeof(buf), NULL) > 0,
+                     UDS_CLIENT_DEFAULT_P2_MS);
+    TEST_MEMORY_EQUAL(buf, EXPECTED_RESP, sizeof(EXPECTED_RESP));
+}
+
 int fn_0x27_noop(UDSServer_t *srv, UDSEvent_t ev, void *arg) {
     switch (ev) {
     case UDS_EVT_SecAccessRequestSeed: {
@@ -3513,6 +3637,13 @@ int main(int ac, char **av) {
         cmocka_unit_test_setup_teardown(test_0x3D_example_2, Setup, Teardown),
         cmocka_unit_test_setup_teardown(test_0x3D_example_3, Setup, Teardown),
         cmocka_unit_test_setup_teardown(test_0x3e_suppress_positive_response, Setup, Teardown),
+        cmocka_unit_test_setup_teardown(test_0x85_control_dtc_setting, Setup, Teardown),
+        cmocka_unit_test_setup_teardown(test_0x85_control_dtc_setting_with_control_data, Setup,
+                                        Teardown),
+        cmocka_unit_test_setup_teardown(test_0x85_control_dtc_setting_request_too_short, Setup,
+                                        Teardown),
+        cmocka_unit_test_setup_teardown(
+            test_0x85_control_dtc_setting_request_returns_negative_response, Setup, Teardown),
         cmocka_unit_test_setup_teardown(test_security_level_resets_on_session_timeout, Setup,
                                         Teardown),
     };


### PR DESCRIPTION
- add tests for the 0x85 function
- emitting the event to the event handler for this function

The update of the iso14229.c/h files are build with a slightly different bazel/gcc version.

```diff
diff --git a/.bazelversion b/.bazelversion
index 0e79152..6da4de5 100644
--- a/.bazelversion
+++ b/.bazelversion
@@ -1 +1 @@
-8.1.1
+8.4.1
diff --git a/toolchain/BUILD b/toolchain/BUILD
index 6ee76bc..c05efe6 100644
--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -77,6 +77,8 @@ gcc_toolchain(
     include_dirs = [
         "/usr/lib/gcc/x86_64-linux-gnu/11/include/",
         '/usr/lib/gcc/x86_64-linux-gnu/13/include/',
+        '/usr/lib/gcc/x86_64-linux-gnu/13/include/',
+        '/usr/lib/gcc/x86_64-pc-linux-gnu/15.2.1/include/',
     ],
     target_compatible_with = [
         "@platforms//cpu:x86_64",
```