### PR TITLE
Fix linux fuzz coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,4 +45,4 @@ jobs:
         # Download and run codecov
         curl -Os https://cli.codecov.io/latest/linux/codecov
         chmod +x codecov
-        ./codecov upload --fail-on-error -t $CODECOV_TOKEN -F fuzz -f coverage.lcov -n "GitHub Actions Fuzz Coverage"
+        ./codecov --verbose upload-process --fail-on-error -t $CODECOV_TOKEN -F fuzz --file coverage.lcov --name "GitHub Actions Fuzz Coverage" --commit-sha $(git rev-parse HEAD) --report-code fuzz-report

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,48 @@
+name: coverage
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  linux-fuzz-coverage:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+    - name: Debug commit info
+      run: |
+        echo "=== Commit Debug Info ==="
+        echo "Current HEAD: $(git rev-parse HEAD)"
+        echo "PR head SHA: ${{ github.event.pull_request.head.sha }}"
+        echo "GitHub SHA: ${{ github.sha }}"
+
+    - name: Setup Bazel Cache
+      uses: ./.github/actions/setup-bazel-cache
+
+    - name: run coverage
+      run: |
+        ./scripts/2_replay_corpus.sh
+
+    - name: upload coverage to Codecov
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      run: |
+        # Verify coverage file exists
+        if [ ! -f coverage.lcov ]; then
+          echo "Error: coverage.lcov file not found"
+          exit 1
+        fi
+        echo "Coverage file size: $(wc -l < coverage.lcov) lines"
+        # Download and run codecov
+        curl -Os https://cli.codecov.io/latest/linux/codecov
+        chmod +x codecov
+        ./codecov upload --fail-on-error -t $CODECOV_TOKEN -F fuzz -f coverage.lcov -n "GitHub Actions Fuzz Coverage"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -61,7 +61,7 @@ jobs:
         # Download and run codecov
         curl -Os https://cli.codecov.io/latest/linux/codecov
         chmod +x codecov
-        ./codecov --verbose upload-process --fail-on-error -t $CODECOV_TOKEN -F fuzz --file coverage.lcov --name "GitHub Actions Fuzz Coverage" --commit-sha $(git rev-parse HEAD) --report-code fuzz-report 
+        ./codecov upload --fail-on-error -t $CODECOV_TOKEN -F fuzz -f coverage.lcov -n "GitHub Actions Fuzz Coverage" 
     
   windows:
     runs-on: windows-latest

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -25,44 +25,6 @@ jobs:
     - name: run unit tests
       run: bazel test //test:all --test_tag_filters=-vcan
     
-  linux-fuzz-coverage:
-    runs-on: ubuntu-22.04
-
-    steps:
-    - name: checkout
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-    - name: Debug commit info
-      run: |
-        echo "=== Commit Debug Info ==="
-        echo "Current HEAD: $(git rev-parse HEAD)"
-        echo "PR head SHA: ${{ github.event.pull_request.head.sha }}"
-        echo "GitHub SHA: ${{ github.sha }}"
-
-    - name: Setup Bazel Cache
-      uses: ./.github/actions/setup-bazel-cache
-
-    - name: run coverage
-      run: |
-        ./scripts/2_replay_corpus.sh
-    
-    - name: upload coverage to Codecov
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      run: |
-        # Verify coverage file exists
-        if [ ! -f coverage.lcov ]; then
-          echo "Error: coverage.lcov file not found"
-          exit 1
-        fi
-        echo "Coverage file size: $(wc -l < coverage.lcov) lines"
-        # Download and run codecov
-        curl -Os https://cli.codecov.io/latest/linux/codecov
-        chmod +x codecov
-        ./codecov --verbose upload-process --fail-on-error -t $CODECOV_TOKEN -F fuzz --file coverage.lcov --name "GitHub Actions Fuzz Coverage" --commit-sha $(git rev-parse HEAD) --report-code fuzz-report 
-    
   windows:
     runs-on: windows-latest
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -61,7 +61,7 @@ jobs:
         # Download and run codecov
         curl -Os https://cli.codecov.io/latest/linux/codecov
         chmod +x codecov
-        ./codecov upload --fail-on-error -t $CODECOV_TOKEN -F fuzz -f coverage.lcov -n "GitHub Actions Fuzz Coverage" 
+        ./codecov --verbose upload-process --fail-on-error -t $CODECOV_TOKEN -F fuzz --file coverage.lcov --name "GitHub Actions Fuzz Coverage" --commit-sha $(git rev-parse HEAD) --report-code fuzz-report 
     
   windows:
     runs-on: windows-latest


### PR DESCRIPTION
The coverage job is failing on PRs from forks because the token is not available. This PR moves the coverage job into a separate workflow, gated by maintainer approval.