### PR TITLE
feat: make config options overridable

### DIFF
--- a/iso14229.h
+++ b/iso14229.h
@@ -1184,22 +1184,30 @@ void UDSServerPoll(UDSServer_t *srv);
 /* Max number of messages the receiver can receive at one time, this value 
  * is affected by can driver queue length
  */
+#ifndef ISO_TP_DEFAULT_BLOCK_SIZE
 #define ISO_TP_DEFAULT_BLOCK_SIZE   8
+#endif
 
 /* The STmin parameter value specifies the minimum time gap allowed between 
  * the transmission of consecutive frame network protocol data units
  */
+#ifndef ISO_TP_DEFAULT_ST_MIN_US
 #define ISO_TP_DEFAULT_ST_MIN_US    0
+#endif
 
 /* This parameter indicate how many FC N_PDU WTs can be transmitted by the 
  * receiver in a row.
  */
+#ifndef ISO_TP_MAX_WFT_NUMBER
 #define ISO_TP_MAX_WFT_NUMBER       1
+#endif
 
 /* Private: The default timeout to use when waiting for a response during a
  * multi-frame send or receive.
  */
+#ifndef ISO_TP_DEFAULT_RESPONSE_TIMEOUT_US
 #define ISO_TP_DEFAULT_RESPONSE_TIMEOUT_US 100000
+#endif
 
 /* Private: Determines if by default, padding is added to ISO-TP message frames.
  */

--- a/src/tp/isotp-c/isotp_config.h
+++ b/src/tp/isotp-c/isotp_config.h
@@ -4,22 +4,30 @@
 /* Max number of messages the receiver can receive at one time, this value 
  * is affected by can driver queue length
  */
+#ifndef ISO_TP_DEFAULT_BLOCK_SIZE
 #define ISO_TP_DEFAULT_BLOCK_SIZE   8
+#endif
 
 /* The STmin parameter value specifies the minimum time gap allowed between 
  * the transmission of consecutive frame network protocol data units
  */
+#ifndef ISO_TP_DEFAULT_ST_MIN_US
 #define ISO_TP_DEFAULT_ST_MIN_US    0
+#endif
 
 /* This parameter indicate how many FC N_PDU WTs can be transmitted by the 
  * receiver in a row.
  */
+#ifndef ISO_TP_MAX_WFT_NUMBER
 #define ISO_TP_MAX_WFT_NUMBER       1
+#endif
 
 /* Private: The default timeout to use when waiting for a response during a
  * multi-frame send or receive.
  */
+#ifndef ISO_TP_DEFAULT_RESPONSE_TIMEOUT_US
 #define ISO_TP_DEFAULT_RESPONSE_TIMEOUT_US 100000
+#endif
 
 /* Private: Determines if by default, padding is added to ISO-TP message frames.
  */


### PR DESCRIPTION
This PR makes the different config options overridable.
Note that this edits a file in the isotp-c library which makes it slightly out-of-sync with upstream.

I could also contribute to isotp-c upstream and then update the whole isotp-c here but I think this may lead to different problems. If you think contributing upstream would make sense I can also do that and later update isotp-c here